### PR TITLE
Disable scheduled workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ name: Go
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 20 * * 1'
+  # schedule:
+  #   - cron:  '0 20 * * 1'
 
   # push:
   #   branches: [ "main" ]


### PR DESCRIPTION
Ticket: https://linear.app/hivemapper/issue/IMCO-208/move-almanac-from-github-actions-to-our-own-backend-run-on-cron

Replaced by network cron job [server/src/tasks/updateUbloxMgaAlmanac.ts](https://github.com/Hivemapper/network/blob/main/server/src/tasks/updateUbloxMgaAlmanac.ts)

TODO (?): Remove this repo entirely